### PR TITLE
Drop superfluous ROS dependency on catkin

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -37,7 +37,7 @@
 
   <author email="thlim@robotis.com">Darby Lim</author>
 
-  <buildtool_depend>catkin</buildtool_depend>
+  <buildtool_depend>cmake</buildtool_depend>
 
   <build_depend>g++-static</build_depend>
   <build_depend>google-mock</build_depend>


### PR DESCRIPTION
This package's CMakeLists.txt doesn't reference catkin at all, and can
be regarded as a "pure CMake" package. In fact, the package.xml already
states that this package is built using cmake directly, but still
depends on catkin.

This change makes the package buildable without catkin, as would be
desired when building with colcon in ROS 2.