### PR TITLE
Fix ceres rosdep key

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -44,7 +44,7 @@
   <build_depend>python-sphinx</build_depend>
 
   <depend>boost</depend>
-  <depend>ceres-solver</depend>
+  <depend>libceres-dev</depend>
   <depend>eigen</depend>
   <depend>libcairo2-dev</depend>
   <depend>libgflags-dev</depend>


### PR DESCRIPTION
The rosdep key is libceres-dev, not ceres-solver.